### PR TITLE
Under debugging tools add my debugger entry into the ring. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,7 @@ http://sixpack.seatgeek.com
 * [pdb](https://docs.python.org/2/library/pdb.html) - (Python standard library) The Python Debugger.
 * [ipdb](https://pypi.python.org/pypi/ipdb) - IPython-enabled pdb.
 * [winpdb](http://winpdb.org/) - A Platform Independent Python Debugger with GUI.
+* [trepan](https://github.com/rocky/python2-trepan/wiki/Overview-and-Features) - A GDB-like Python Debugger
 * [pudb](https://pypi.python.org/pypi/pudb) – A full-screen, console-based Python debugger.
 * [pyringe](https://github.com/google/pyringe) - Debugger capable of attaching to and injecting code into Python processes.
 * [memory_profiler](https://github.com/fabianp/memory_profiler) - Monitor Memory usage of Python code.


### PR DESCRIPTION
In my biased opinion, trepan has features that I am not aware of in other debuggers. Namely: 

* extensive documentation in RestructuredText so it looks nice on pypy  as well as inside the debugger using terminal highlighting
* context-sensitive command completion
*  debugger macros that can be written in python
*  source-code syntax highlighting
*  stepping and filtering by event (call, return, c_call, c_return, line, exception ...)
*  a smart "eval" command

and more... See https://pypi.python.org/pypi/trepan/0.4.1